### PR TITLE
알람 설정할 때 시간을 조절하면 오전/오후가 오전으로 강제 셋팅되는 버그

### DIFF
--- a/app/src/main/java/com/easyo/pairalarm/util/BindingAdapter.kt
+++ b/app/src/main/java/com/easyo/pairalarm/util/BindingAdapter.kt
@@ -34,6 +34,7 @@ object BindingAdapter {
     @BindingAdapter("hourForAMPM", "minForAMPM")
     fun NumberPicker.setAMPM(hourForAMPM: Int, minForAMPM: Int) {
         this.value = when {
+            this.value == 1 -> 1
             hourForAMPM > 12 -> 1
             hourForAMPM == 12 && minForAMPM > 0 -> 1
             else -> 0


### PR DESCRIPTION
# 원인
1. 시간을 셋팅하면 강제로 오전으로 셋팅되는 버그 

# 수정 내용
1. 오후일 때는 고정적으로 오후로 표시되게 변경

# 확인
- [x] 빌드 완료
