### PR TITLE
잠금 화면 위에 액티비티 띄우기

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
             android:name=".ui.activity.OnAlarmActivity"
             android:exported="false"
             android:launchMode="singleTask"
+            android:showOnLockScreen="true"
+            android:excludeFromRecents="true"
             android:theme="@style/Theme.PairAlarm.NoActionBar"
             />
         <activity

--- a/app/src/main/java/com/easyo/pairalarm/ui/activity/OnAlarmActivity.kt
+++ b/app/src/main/java/com/easyo/pairalarm/ui/activity/OnAlarmActivity.kt
@@ -1,5 +1,6 @@
 package com.easyo.pairalarm.ui.activity
 
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Handler
@@ -29,8 +30,14 @@ class OnAlarmActivity : AppCompatActivity() {
         binding = ActivityOnAlarmBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.lifecycleOwner = this
-
         val alarmCode = intent.getStringExtra(ALARM_CODE_TEXT)
+
+        // 안드12 이상에서 잠금화면 위로 액티비티 띄우기 & 화면 켜기
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        }
+
         val callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
 


### PR DESCRIPTION
# 개요
안드로이드12 이상에선 잠금 화면 위로 액티비티를 띄우기 위해선 특별한 처리를 해야한다.

# 수정 내용

# 확인
- [ ] 빌드 완료
- [ ] 작성한 코드 동작 확인 완료
