### PR TITLE
setting에서 자동으로 설정한 값이 셋팅되어있지 않은 버그

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/API_33_xxhdpi_1080_2400.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="R3CT30JJRKZ" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-13T09:55:21.393184Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-14T01:48:36.455369Z" />
   </component>
 </project>

--- a/app/src/main/java/com/easyo/pairalarm/ui/dialog/BellSelectDialogFragment.kt
+++ b/app/src/main/java/com/easyo/pairalarm/ui/dialog/BellSelectDialogFragment.kt
@@ -19,7 +19,7 @@ class BellSelectDialogFragment(
     private val clickSaveButton: (clickedBellIndex: Int) -> Unit
 ) : DialogFragment() {
     private lateinit var binding: DialogBellSetBinding
-    private var bellIndex = 0
+    private var bellIndex = selectedBellIndex
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
# 원인
최초 값을 설정하지 않았기 때문에 문제 발생함

# 수정 내용
벨 선택에서 선택을 하지 않고 save 버튼을 누르면 항상 첫 번째 벨이 선택되는 버그 해결

# 확인
- [x] 빌드 완료
- [x] 작성한 코드 동작 확인 완료
